### PR TITLE
Fix typo in container registry domain

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -40,8 +40,8 @@ jobs:
         git checkout v@${{ github.event.inputs.version }}
         mvn spring-boot:build-image
       env:
-        IMAGE_NAME: ghrc.io/${{ github.repository }}:${{ github.event.inputs.version }}
+        IMAGE_NAME: ghcr.io/${{ github.repository }}:${{ github.event.inputs.version }}
         PUBLISH: true
-        REPO_URL: https://ghrc.io
+        REPO_URL: https://ghcr.io
         REPO_USERNAME:  ${{ github.actor }}
         REPO_PWD: ${{ secrets.GITHUB_TOKEN }}

--- a/github-variables.txt
+++ b/github-variables.txt
@@ -1,5 +1,5 @@
-IMAGE_NAME: ghrc.io/eduardomallmann/viacep-proxy
+IMAGE_NAME: ghcr.io/eduardomallmann/viacep-proxy
 PUBLISH: true
-REPO_URL: https://ghrc.io
+REPO_URL: https://ghcr.io
 REPO_USERNAME: eduardomallmann
 REPO_PWD: ${{ github.token }}


### PR DESCRIPTION
Hi `eduardomallmann/viacep-proxy`!

This is not an automatic, 🤖-generated PR, as you can check in my [GitHub profile](https://github.com/p-), I work for GitHub and I am part of the [GitHub Security Lab](https://securitylab.github.com/).

While performing a code search for container registry domains we noticed that this repo contains a misspelled domain name.

If a malicious actor were in control of that misspelled domain, they could potentially perform an attack on the software supply chain of this project and/or steal the credentials used to connect to the container registry (depending on how the misspelled domain name of the container registry is used).
Please fix this typo and check your documentation for similar typos.